### PR TITLE
Fixed corner case when sample is a minimal Int16

### DIFF
--- a/ulaw.go
+++ b/ulaw.go
@@ -29,7 +29,7 @@ func MLawEncodeSample(s int16) uint8 {
 	if s >= 0 {
 		return μLawCompressTable[s>>4]
 	}
-	return 0x7f & μLawCompressTable[-s>>4]
+	return 0x7f & μLawCompressTable[-int(s)>>4]
 }
 
 // MLawDecodeSample decodes an μ-law sample to PCM16.


### PR DESCRIPTION
The int16 sample can be in range from -32768 to 32767.
Therefore it is not possible to take a modulo of int16 -32768.